### PR TITLE
Fix compilation for GHC 7.2.1

### DIFF
--- a/System/Posix/Daemonize.hs
+++ b/System/Posix/Daemonize.hs
@@ -49,7 +49,8 @@ import Control.Monad.Trans
 import Control.Exception.Extensible
 import qualified Control.Monad as M (forever)
 import Prelude hiding (catch)
-import System
+import System.Exit (ExitCode(..))
+import System.Environment (getArgs, getProgName)
 import System.Posix
 import System.Posix.Syslog (withSyslog,Option(..),Priority(..),Facility(..),syslog)
 import System.FilePath.Posix (joinPath)

--- a/hdaemonize.cabal
+++ b/hdaemonize.cabal
@@ -17,7 +17,7 @@ Build-Type:	Simple
 Extra-Source-Files:	README
 
 Library
-  Build-Depends:	base >= 4 && < 5, unix, haskell98, hsyslog, extensible-exceptions, filepath, mtl
+  Build-Depends:	base >= 4 && < 5, unix, hsyslog, extensible-exceptions, filepath, mtl
   Exposed-modules:      System.Posix.Daemonize
   if impl(ghc > 6.12)
       Ghc-Options:      -Wall -fno-warn-unused-do-bind -fno-warn-type-defaults -fno-warn-name-shadowing


### PR DESCRIPTION
From GHC 7.2.1 on it is no longer possible to use the `haskell98`
package together with the `base` package. This conflict is resolved by
removing the dependancy on `haskell98` from `hdaemonize`.
