### PR TITLE
hsyslog 2.0 has major changes in withSyslog. Hence we depend on hsyslog ...

### DIFF
--- a/System/Posix/Daemonize.hs
+++ b/System/Posix/Daemonize.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
 module System.Posix.Daemonize (
   -- * Simple daemonization
   daemonize, 
@@ -58,7 +59,7 @@ import Prelude hiding (catch)
 import System.Environment
 import System.Exit
 import System.Posix
-import System.Posix.Syslog (withSyslog,Option(..),Priority(..),Facility(..),syslog)
+import System.Posix.Syslog (withSyslog,Option(..),Priority(..),Facility(..),syslog, logUpTo)
 import System.FilePath.Posix (joinPath)
 import Data.Maybe (isNothing, fromMaybe, fromJust)
 
@@ -147,7 +148,7 @@ serviced daemon = do
   process daemon' args
     where
       
-      program' daemon = withSyslog (fromJust $ name daemon) (syslogOptions daemon) DAEMON $
+      program' daemon = withSyslog (fromJust $ name daemon) (syslogOptions daemon) DAEMON (logUpTo Debug) $
                       do let log = syslog Notice
                          log "starting"
                          pidWrite daemon

--- a/hdaemonize.cabal
+++ b/hdaemonize.cabal
@@ -17,7 +17,7 @@ Build-Type:	Simple
 Extra-Source-Files:	README
 
 Library
-  Build-Depends:	base >= 4 && < 5, unix, hsyslog, extensible-exceptions, filepath, mtl
+  Build-Depends:	base >= 4 && < 5, unix, hsyslog >= 2.0, extensible-exceptions, filepath, mtl
   Exposed-modules:      System.Posix.Daemonize
   Extensions:           CPP
   if impl(ghc > 6.12)


### PR DESCRIPTION
...>= 2.0 and use the new withSyslog definition from the new api.
